### PR TITLE
Auto generate IDs (for <defs>) during render, with SSR support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
  "extends": "airbnb",
  "root": true,
- rules: {
+ "rules": {
   "react/require-default-props": "off",
   "react/jsx-filename-extension": "off",
   "no-plusplus": "off"

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,9 @@
 {
  "extends": "airbnb",
- "root": true
+ "root": true,
+ rules: {
+  "react/require-default-props": "off",
+  "react/jsx-filename-extension": "off",
+  "no-plusplus": "off"
+ }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # gitignore
 node_modules
 lib
+*.tgz
 
 # Only apps should have lockfiles
 npm-shrinkwrap.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-node_modules
-src
-*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 node_modules
 src
+*.tgz

--- a/auto-id.js
+++ b/auto-id.js
@@ -1,0 +1,4 @@
+module.exports = {
+  AutoIdProvider: require('./lib/AutoIdProvider').default,
+  useId: require('./lib/useId').default,
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "build": "babel src --out-dir lib",
     "lint": "eslint src/",
     "prepare": "npm run build",
-    "prepublish": "npm run build",
     "pretest": "npm run lint"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "auto-id.js"
   ],
   "main": "lib/index.js",
+  "sideEffects": false,
   "scripts": {
     "test": "npm run tests-only",
     "pretests-only": "npm run build",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "babel-plugin-inline-react-svg",
   "version": "1.1.1",
   "description": "A babel plugin that optimizes and inlines SVGs for your react components.",
+  "files": [
+    "lib",
+    "auto-id.js"
+  ],
   "main": "lib/index.js",
   "scripts": {
     "test": "npm run tests-only",

--- a/package.json
+++ b/package.json
@@ -40,15 +40,17 @@
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.12.4",
-    "react": "^15.3.1"
+    "react": "^16.8.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0"
+    "@babel/core": "^7.0.0",
+    "react": "^16.8.0"
   },
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/parser": "^7.0.0",
     "lodash.isplainobject": "^4.0.6",
+    "prop-types": "^15.7.2",
     "resolve": "^1.10.0",
     "svgo": "^0.7.2"
   }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@babel/cli": "^7.4.3",
     "@babel/core": "^7.0.0",
     "@babel/node": "^7.2.2",
+    "@babel/preset-env": "^7.8.4",
     "@babel/preset-react": "^7.0.0",
     "babel-preset-airbnb": "^3.2.1",
     "eslint": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "tests-only": "babel-node test/sanity.js",
     "build": "babel src --out-dir lib",
     "lint": "eslint src/",
+    "prepare": "npm run build",
     "prepublish": "npm run build",
     "pretest": "npm run lint"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "npm run tests-only",
     "pretests-only": "npm run build",
     "tests-only": "babel-node test/sanity.js",
-    "build": "babel src --out-dir lib",
+    "build": "babel src --out-dir lib --verbose",
     "lint": "eslint src/",
     "prepare": "npm run build",
     "pretest": "npm run lint"

--- a/src/AutoIdProvider.js
+++ b/src/AutoIdProvider.js
@@ -3,8 +3,16 @@ import PropTypes from 'prop-types';
 
 let globalId = 0;
 
+// By default, if no AutoIdProvider is present, this `globalId` is the ID
+// counter. This will work fine for browser-only apps. For SSR support, use
+// AutoIdProvider, which will have a scoped counter per request.
 const Context = React.createContext(() => `svg-id-${globalId++}`);
 
+/**
+ * Provide auto generated IDs for the `useId` hook, with support for a custom
+ * ID generator. Using this will ensure that each server-side request that
+ * renders your app has their own ID counter that starts at 0.
+ */
 export default function AutoIdProvider({ children, getId: customGetId }) {
   const nextId = useRef(0);
 

--- a/src/AutoIdProvider.js
+++ b/src/AutoIdProvider.js
@@ -1,0 +1,24 @@
+import React, { useCallback, useRef } from 'react';
+import PropTypes from 'prop-types';
+
+let globalId = 0;
+
+const Context = React.createContext(() => `svg-id-${globalId++}`);
+
+export default function AutoIdProvider({ children, getId: customGetId }) {
+  const nextId = useRef(0);
+
+  const getId = useCallback(
+    () => (customGetId ? customGetId(nextId) : `svg-id-${nextId.current++}`),
+    [customGetId],
+  );
+
+  return <Context.Provider value={getId}>{children}</Context.Provider>;
+}
+
+AutoIdProvider.Context = Context;
+
+AutoIdProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  getId: PropTypes.func,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ export default declare(({
     SVG_DEFAULT_PROPS_CODE,
     NUM_IDS = 0,
   }) => {
-    const useIds = new Array(NUM_IDS).fill('useId()');
+    const useIds = new Array(NUM_IDS).fill('AutoId.useId()');
     const ID_HOOKS = `var ids = [${useIds.join(', ')}]`;
     const namedTemplate = `
       var SVG_NAME = function SVG_NAME(props) {
@@ -134,8 +134,8 @@ export default declare(({
         const svgReplacement = buildSvg(opts);
         path.replaceWith(svgReplacement);
       }
-      file.get('ensureUseId')();
-      file.set('ensureUseId', () => {});
+      file.get('ensureAutoId')();
+      file.set('ensureAutoId', () => {});
       file.get('ensureReact')();
       file.set('ensureReact', () => {});
     }
@@ -154,16 +154,16 @@ export default declare(({
           if (!path.scope.hasBinding('useId')) {
             const autoIdModule = opts.autoIdModule || 'babel-plugin-inline-react-svg/auto-id';
 
-            const useIdImportDeclaration = t.importDeclaration([
-              t.importSpecifier(t.identifier('useId'), t.identifier('useId')),
+            const autoIdImportDeclaration = t.importDeclaration([
+              t.importDefaultSpecifier(t.identifier('AutoId')),
             ], t.stringLiteral(autoIdModule));
 
-            file.set('ensureUseId', () => {
-              const [newPath] = path.unshiftContainer('body', useIdImportDeclaration);
+            file.set('ensureAutoId', () => {
+              const [newPath] = path.unshiftContainer('body', autoIdImportDeclaration);
               newPath.get('specifiers').forEach((specifier) => { path.scope.registerBinding('module', specifier); });
             });
           } else {
-            file.set('ensureUseId', () => {});
+            file.set('ensureAutoId', () => {});
           }
           if (!path.scope.hasBinding('React')) {
             const reactImportDeclaration = t.importDeclaration([

--- a/src/index.js
+++ b/src/index.js
@@ -152,9 +152,11 @@ export default declare(({
             throw new TypeError('the "filename" option is required when transforming code');
           }
           if (!path.scope.hasBinding('useId')) {
+            const autoIdModule = opts.autoIdModule || 'babel-plugin-inline-react-svg/auto-id';
+
             const useIdImportDeclaration = t.importDeclaration([
               t.importSpecifier(t.identifier('useId'), t.identifier('useId')),
-            ], t.stringLiteral('babel-plugin-inline-react-svg/auto-id'));
+            ], t.stringLiteral(autoIdModule));
 
             file.set('ensureUseId', () => {
               const [newPath] = path.unshiftContainer('body', useIdImportDeclaration);

--- a/src/index.js
+++ b/src/index.js
@@ -26,12 +26,12 @@ export default declare(({
     SVG_CODE,
     SVG_DEFAULT_PROPS_CODE,
     NUM_IDS = 0,
+    HOOK_NAME,
   }) => {
-    const useIds = new Array(NUM_IDS).fill('AutoId.useId()');
-    const ID_HOOKS = `var ids = [${useIds.join(', ')}]`;
+    const useIds = new Array(NUM_IDS).fill('HOOK_NAME()');
     const namedTemplate = `
       var SVG_NAME = function SVG_NAME(props) {
-        ${NUM_IDS ? 'ID_HOOKS;' : ''}
+        ${NUM_IDS ? `var ids = [${useIds.join(', ')}];` : ''}
         return SVG_CODE;
       };
       ${SVG_DEFAULT_PROPS_CODE ? 'SVG_NAME.defaultProps = SVG_DEFAULT_PROPS_CODE;' : ''}
@@ -39,7 +39,7 @@ export default declare(({
     `;
     const anonymousTemplate = `
       var Component = function (props) {
-        ${NUM_IDS ? 'ID_HOOKS;' : ''}
+        ${NUM_IDS ? `var ids = [${useIds.join(', ')}];` : ''}
         return SVG_CODE;
       };
       ${SVG_DEFAULT_PROPS_CODE ? 'Component.defaultProps = SVG_DEFAULT_PROPS_CODE;' : ''}
@@ -49,13 +49,13 @@ export default declare(({
 
     if (SVG_NAME !== 'default') {
       return template(namedTemplate)(NUM_IDS ? {
-        SVG_NAME, SVG_CODE, SVG_DEFAULT_PROPS_CODE, ID_HOOKS,
+        SVG_NAME, SVG_CODE, SVG_DEFAULT_PROPS_CODE, HOOK_NAME,
       } : {
         SVG_NAME, SVG_CODE, SVG_DEFAULT_PROPS_CODE,
       });
     }
     return template(anonymousTemplate)(NUM_IDS ? {
-      SVG_CODE, SVG_DEFAULT_PROPS_CODE, EXPORT_FILENAME, ID_HOOKS,
+      SVG_CODE, SVG_DEFAULT_PROPS_CODE, EXPORT_FILENAME, HOOK_NAME,
     } : {
       SVG_CODE, SVG_DEFAULT_PROPS_CODE, EXPORT_FILENAME,
     });
@@ -102,12 +102,20 @@ export default declare(({
 
       const svgCode = traverse.removeProperties(parsedSvgAst.program.body[0].expression);
 
+      file.get('ensureAutoId')();
+      file.set('ensureAutoId', () => {});
+      file.get('ensureReact')();
+      file.set('ensureReact', () => {});
+
+      const hookIdentifier = path.scope.getBinding('useId').identifier;
+
       const opts = {
         SVG_NAME: importIdentifier,
         SVG_CODE: svgCode,
         IS_EXPORT: isExport,
         EXPORT_FILENAME: exportFilename,
         NUM_IDS: ids.size,
+        HOOK_NAME: hookIdentifier,
       };
 
       // Move props off of element and into defaultProps
@@ -134,10 +142,6 @@ export default declare(({
         const svgReplacement = buildSvg(opts);
         path.replaceWith(svgReplacement);
       }
-      file.get('ensureAutoId')();
-      file.set('ensureAutoId', () => {});
-      file.get('ensureReact')();
-      file.set('ensureReact', () => {});
     }
   }
 
@@ -151,11 +155,12 @@ export default declare(({
           if (typeof filename === 'undefined' && typeof opts.filename !== 'string') {
             throw new TypeError('the "filename" option is required when transforming code');
           }
+
           if (!path.scope.hasBinding('useId')) {
             const autoIdModule = opts.autoIdModule || 'babel-plugin-inline-react-svg/auto-id';
 
             const autoIdImportDeclaration = t.importDeclaration([
-              t.importDefaultSpecifier(t.identifier('AutoId')),
+              t.importSpecifier(t.identifier('useId'), t.identifier('useId')),
             ], t.stringLiteral(autoIdModule));
 
             file.set('ensureAutoId', () => {
@@ -165,6 +170,7 @@ export default declare(({
           } else {
             file.set('ensureAutoId', () => {});
           }
+
           if (!path.scope.hasBinding('React')) {
             const reactImportDeclaration = t.importDeclaration([
               t.importDefaultSpecifier(t.identifier('React')),

--- a/src/transformSvg.js
+++ b/src/transformSvg.js
@@ -63,7 +63,7 @@ export default (t, state) => ({
           );
         }
       } else {
-        const idRefMatch = /^url\(#([^)]+)\)$/.exec(node.value.value);
+        const idRefMatch = /^url\(['"]?#([^)]+)['"]?\)$/.exec(node.value.value);
         if (idRefMatch) {
           const idToRewrite = idRefMatch[1];
           let index = state.ids.get(idToRewrite);

--- a/src/transformSvg.js
+++ b/src/transformSvg.js
@@ -46,7 +46,11 @@ export default (t, state) => ({
         // to move the `ids[n]` expression there because it will break. Instead
         // of messing with that behavior, let's just don't try to fiddle with
         // `id` props on the root `<svg>`.
-        const isSvgId = Boolean(parent && parent.type === 'JSXOpeningElement' && parent.name.name.toLowerCase() === 'svg');
+        const isSvgId = Boolean(
+          parent
+          && parent.type === 'JSXOpeningElement'
+          && parent.name.name.toLowerCase() === 'svg',
+        );
         if (!isSvgId) {
           const idToRewrite = node.value.value;
           let index = state.ids.get(idToRewrite);

--- a/src/transformSvg.js
+++ b/src/transformSvg.js
@@ -41,6 +41,11 @@ export default (t, state) => ({
       }
 
       if (originalName.name === 'id') {
+        // This plugin detects when props (including `id`) are on the root
+        // `<svg>` element and moves them to `defaultProps`. We don't want it
+        // to move the `ids[n]` expression there because it will break. Instead
+        // of messing with that behavior, let's just don't try to fiddle with
+        // `id` props on the root `<svg>`.
         const isSvgId = Boolean(parent && parent.type === 'JSXOpeningElement' && parent.name.name.toLowerCase() === 'svg');
         if (!isSvgId) {
           const idToRewrite = node.value.value;

--- a/src/useId.js
+++ b/src/useId.js
@@ -1,0 +1,8 @@
+import { useContext, useState } from 'react';
+import AutoIdProvider from './AutoIdProvider';
+
+export default function useId(customId) {
+  const getId = useContext(AutoIdProvider.Context);
+  const [autoId] = useState(getId);
+  return customId || autoId;
+}

--- a/test/fixtures/ids.svg
+++ b/test/fixtures/ids.svg
@@ -1,0 +1,12 @@
+<svg data-name="ids" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient id="myGradient" gradientTransform="rotate(90)">
+      <stop offset="5%"  stop-color="gold" />
+      <stop offset="95%" stop-color="red" />
+    </linearGradient>
+  </defs>
+
+  <!-- using my linear gradient -->
+  <circle cx="5" cy="5" r="4" fill="url('#myGradient')" />
+</svg>

--- a/test/fixtures/test-ids.jsx
+++ b/test/fixtures/test-ids.jsx
@@ -1,0 +1,11 @@
+import MySvg from './ids.svg';
+
+export default function MyFunctionIcon() {
+  return <MySvg />;
+}
+
+export class MyClassIcon extends React.Component {
+  render() {
+    return <MySvg />;
+  }
+}

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -177,3 +177,14 @@ transformFile('test/fixtures/test-export-default-as.jsx', {
   if (err) throw err;
   console.log('test/fixtures/test-export-default-as.jsx', result.code);
 });
+
+transformFile('test/fixtures/test-ids.jsx', {
+  babelrc: false,
+  presets: [['@babel/preset-env', { modules: 'commonjs' }], '@babel/preset-react'],
+  plugins: [
+    inlineReactSvgPlugin,
+  ],
+}, (err, result) => {
+  if (err) throw err;
+  console.log('test/fixtures/test-ids.jsx', result.code);
+});


### PR DESCRIPTION
One common complaint is that rendering the same SVG multiple times results in duplicate IDs on the page. See airbnb/babel-plugin-inline-react-svg#57.

IDs are pretty much necessary for using things like gradients. The problem is since the SVG is rendered inline, and sometimes the same SVG is rendered multiple times, the IDs are duplicated on the page. This is not only invalid, but results in actual bugs.

For example, let's say one of the SVGs becomes hidden:

```html
<div style="display: none">
  <svg>...</svg>
</div>

<svg>...</svg>
```

Did you know hiding the elements that `url(#foo)` references in an SVG cause their referents to also hide (in some browsers at least)? Yeah, weird. Even though the ID'd elements are still in the DOM, hiding them causes their reference to hide also.

In our case, we are rendering country flag icons both in a dropdown and in a footer. When the dropdown is hidden, so are all the flags in the footer.

This patch adds runtime code similar to [Reach UI's Auto ID](https://reacttraining.com/reach-ui/auto-id/). **NOTE THAT THIS MEANS YOU'LL NEED TO CHANGE `babel-plugin-inline-react-svg` TO BE IN `dependencies`, NOT `devDependencies`.** All IDs are replaced with references to the (newly built-in) `useId()` hook. This ensures that you can render the same SVG as many times as you like, and each instance will have unique IDs.

If using server-side rendering (SSR), you can wrap your app in the `<AutoIdProvider>` that's also exported, which will ensure that the IDs match up during hydration.

```js
import { AutoIdProvider } from 'babel-plugin-inline-react-svg/auto-id';
```

**Would using `<use>` and/or shared non-hidden `<defs>` be technically better?**

Yes, but extremely complicated. This requires a central manager and portals, which are both quite difficult for SSR (we'd need some specialized helper like `react-helmet` or `next/head`, except for stuff in `<body>` instead of `<head>`).

Fixes airbnb/babel-plugin-inline-react-svg#57.